### PR TITLE
changed download url arch linux to 2014-03-01

### DIFF
--- a/archlinux-x86_64/template.json
+++ b/archlinux-x86_64/template.json
@@ -2,8 +2,8 @@
   "builders": [{
     "type": "virtualbox-iso",
     "guest_os_type": "Linux",
-    "iso_url": "http://cake.lib.fit.edu/archlinux/iso/2013.12.01/archlinux-2013.12.01-dual.iso",
-    "iso_checksum": "1b25847658fb94ed92beef9d5e1f3bb2",
+    "iso_url": "http://cake.lib.fit.edu/archlinux/iso/2014.03.01/archlinux-2014.03.01-dual.iso",
+    "iso_checksum": "d0c93ab40c4fd8959bfb5c7e5989c777",
     "iso_checksum_type": "md5",
     "ssh_username": "root",
     "ssh_password": "vagrant",


### PR DESCRIPTION
Hello,

Version 2013.12.01 got a 404 so i updated it to the latest version

==> virtualbox-iso: Gracefully halting virtual machine...
==> virtualbox-iso: Preparing to export machine...
    virtualbox-iso: Deleting forwarded port mapping for SSH (host port 2822)
==> virtualbox-iso: Exporting virtual machine...
==> virtualbox-iso: Unregistering and deleting virtual machine...
==> virtualbox-iso: Running post-processor: vagrant
==> virtualbox-iso (vagrant): Creating Vagrant box for 'virtualbox' provider
    virtualbox-iso (vagrant): Copying from artifact: output-virtualbox-iso/packer-virtualbox-iso-disk1.vmdk
    virtualbox-iso (vagrant): Copying from artifact: output-virtualbox-iso/packer-virtualbox-iso.ovf
    virtualbox-iso (vagrant): Renaming the OVF to box.ovf...
    virtualbox-iso (vagrant): Compressing: Vagrantfile
    virtualbox-iso (vagrant): Compressing: box.ovf
    virtualbox-iso (vagrant): Compressing: metadata.json
    virtualbox-iso (vagrant): Compressing: packer-virtualbox-iso-disk1.vmdk
Build 'virtualbox-iso' finished.

==> Builds finished. The artifacts of successful builds are:
--> virtualbox-iso: 'virtualbox' provider box: packer_virtualbox-iso_virtualbox.box
